### PR TITLE
Enable pry and byebug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ x-app: &app
   depends_on:
     - postgres
     - redis
+  tty: true
+  stdin_open: true 
 
 services:
   postgres:


### PR DESCRIPTION
Make `binding.pry` and `byebug` work when starting the stack with something like `docker-compose up -d && docker attach $(docker-compose ps -q web)` or `docker-compose up`